### PR TITLE
Change outdated link.

### DIFF
--- a/pages/02.documentation/01.registration-and-login/default.en.md
+++ b/pages/02.documentation/01.registration-and-login/default.en.md
@@ -9,7 +9,7 @@ taxonomy:
         - gui
 ---
 
-To gain access to SysEleven MetaKube you need to register for [SysEleven Stack](https://www.syseleven.de/syseleven-stack/). If your company already has a SysEleven Stack project and you want to add accounts for more team members, please contact our [support](../../05.support/default.en.md).
+To gain access to SysEleven MetaKube you need to register for [SysEleven Stack](https://www.syseleven.de/produkte-services/syseleven-stack/). If your company already has a SysEleven Stack project and you want to add accounts for more team members, please contact our [support](../../05.support/default.en.md).
 
 Once you have access to the SysEleven Stack, open a web browser and visit [metakube.syseleven.de](https://metakube.syseleven.de/). You will be greeted by a `Login` button:
 


### PR DESCRIPTION
Change link in registration and login page to  https://www.syseleven.de/produkte-services/syseleven-stack/