### PR TITLE
Change reference from stable/nginx-ingress to ingress-nginx.

### DIFF
--- a/pages/04.tutorials/15.create-an-ingress-controller/default.en.md
+++ b/pages/04.tutorials/15.create-an-ingress-controller/default.en.md
@@ -23,7 +23,8 @@ The easiest way to install it in your cluster is by installing the fully managed
 Alternatively you can install it manually through [Helm](../17.using-helm/default.en.md). When Helm is ready to be used, run:
 
 ```bash
-helm install stable/nginx-ingress --name nginx-ingress --namespace kube-system  --set "rbac.create=true" --set "controller.replicaCount=2" --set "defaultBackend.replicaCount=2"
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm install ingress-nginx/ingress-nginx --name nginx-ingress --namespace kube-system  --set "rbac.create=true" --set "controller.replicaCount=2" --set "defaultBackend.replicaCount=2"
 ```
 
 to install the NGINX Ingress Controller in the cluster. This will automatically create a [Type Load Balancer service](../13.create-a-load-balancer/default.en.md) for you.

--- a/pages/04.tutorials/27.setup-an-nginx-ingress-controller-with-the-proxy-protocol/default.en.md
+++ b/pages/04.tutorials/27.setup-an-nginx-ingress-controller-with-the-proxy-protocol/default.en.md
@@ -84,8 +84,11 @@ This will deploy three replicas of the nginx ingress controller with autoscaling
 # Create a namespace to deploy the nginx ingress controller into
 kubectl create namespace nginx-ingress
 
+# Add the ingress contrller helm repository if it is not added.
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+
 # Deploy the nginx ingress controller
-helm upgrade --install -f values.yaml --namespace nginx-ingress nginx-ingress stable/nginx-ingress
+helm upgrade --install -f values.yaml --namespace nginx-ingress nginx-ingress ingress-nginx/ingress-nginx
 ```
 
 ## Additional configuration options. Preserve the Load balancers external IP address (floating IP)


### PR DESCRIPTION
This PR changes reference from the deprecated `stable/nginx-ingress` helm chart to the new `ingress-nginx` helm chart repository.