### PR TITLE
Add octavia banner to proxy protcol turorial

### DIFF
--- a/pages/04.tutorials/27.setup-an-nginx-ingress-controller-with-the-proxy-protocol/default.en.md
+++ b/pages/04.tutorials/27.setup-an-nginx-ingress-controller-with-the-proxy-protocol/default.en.md
@@ -9,6 +9,9 @@ taxonomy:
         - proxy protocol
 ---
 
+! This tutorial only works with clusters using kubernetes version > 1.17
+! Starting with kubernetes version 1.18 we are using octavia to create loadbalancers which has some new configuration options that the old one doesn't support
+
 ## Overview
 
 You can configure the nginx ingress controller in various ways. To use the Openstack load balancer Octavia with ssl offloading you will need to configure the ingress controller with the proxy protocol. The alternative would be to use the Openstack service barbican to store your ssl certificate. Which is currently not directly supported by Kubernetes.


### PR DESCRIPTION
This should make it clearer for users that only 1.18+ supports this.

Beforehand it was only mentioned indirectly within the tutorial itself.