### PR TITLE
Add docs for custom floating ip network

### DIFF
--- a/pages/04.tutorials/13.create-a-load-balancer/default.en.md
+++ b/pages/04.tutorials/13.create-a-load-balancer/default.en.md
@@ -76,3 +76,21 @@ Among others this makes a few interesting scenarios possible:
 - Making sure to always have the same IP because other systems/firewalls depend on it.
 
 !!! If you need even more control of your used IP addresses you can also rent a dedicated IP space from us or [bring your own IP space](https://docs.syseleven.de/syseleven-stack/de/reference/network#customer-public-ip-space-bring-your-own-ip), please contact us if you are interested.
+
+## Use a custom floating ip network
+
+The example below configures the service to use a custom floating ip network. You will need to add the floating ip network id you have to the service.
+By default the standard metakube floating ip network will be used and no further configuration is required.
+
+### Additional yaml to add to the service for a custom floating ip network
+
+```yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: ...
+  annotations:
+    loadbalancer.openstack.org/floating-network-id: "*****"
+spec:
+  ...
+```

--- a/pages/04.tutorials/27.setup-an-nginx-ingress-controller-with-the-proxy-protocol/default.en.md
+++ b/pages/04.tutorials/27.setup-an-nginx-ingress-controller-with-the-proxy-protocol/default.en.md
@@ -112,6 +112,23 @@ The example below configures the nginx ingress controller after the first update
     type: LoadBalancer
 ```
 
+## Additional configuration options. Use a custom floating ip network (optional)
+
+The example below configures the nginx ingress controller below to use a custom floating ip network. You will need to add the floating ip network id you have created to the service.
+By default the standard metakube floating ip network will be used and no further configuration is required.
+
+### Additional yaml to add to the nginx ingress controller for a custom floating ip network (optional)
+
+```yaml
+  service:
+    enabled: true
+
+    annotations:
+      loadbalancer.openstack.org/floating-network-id: "*****"
+
+    type: LoadBalancer
+```
+
 ## Documentation with further configuration options
 
 The openstack external cloud provider has a list of all supported service annotations you may use. You can find the documentation here:

--- a/pages/04.tutorials/27.setup-an-nginx-ingress-controller-with-the-proxy-protocol/default.en.md
+++ b/pages/04.tutorials/27.setup-an-nginx-ingress-controller-with-the-proxy-protocol/default.en.md
@@ -112,25 +112,12 @@ The example below configures the nginx ingress controller after the first update
     type: LoadBalancer
 ```
 
-## Additional configuration options. Use a custom floating ip network (optional)
-
-The example below configures the nginx ingress controller below to use a custom floating ip network. You will need to add the floating ip network id you have created to the service.
-By default the standard metakube floating ip network will be used and no further configuration is required.
-
-### Additional yaml to add to the nginx ingress controller for a custom floating ip network (optional)
-
-```yaml
-  service:
-    enabled: true
-
-    annotations:
-      loadbalancer.openstack.org/floating-network-id: "*****"
-
-    type: LoadBalancer
-```
-
 ## Documentation with further configuration options
 
 The openstack external cloud provider has a list of all supported service annotations you may use. You can find the documentation here:
 
 [Exposing applications using services of LoadBalancer type](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/expose-applications-using-loadbalancer-type-service.md)
+
+For more informations about how to configure a loadbalancer service you can read this tutorial:
+
+[Create a Load Balancer](https://docs.syseleven.de/metakube/en/tutorials/create-a-load-balancer)


### PR DESCRIPTION
Describe how to change the nginx ingress configuration to use a custom
floating ip network.

Explain that this is not needed when using the default metakube network.