### PR TITLE
Syseleven/fix unsafe sysctl layout

### DIFF
--- a/pages/04.tutorials/32.confiugre-unsafe-sysctls/default.en.md
+++ b/pages/04.tutorials/32.confiugre-unsafe-sysctls/default.en.md
@@ -11,19 +11,9 @@ taxonomy:
         - securityContext
 ---
 
-At some point during your Kubernetes journey you will come to the point where
-you need to adjust some parameters of the underlying node system, either
-globally or in the context of a specific pod or set of pods. Maybe you are
-running Redis and need to
-[increase the amount of allowed maximum connections](https://github.com/redis/redis/blob/unstable/redis.conf#L100)
-on a socket or you use Apache webserver and want to
-[enable TCP Keepalive](http://httpd.apache.org/docs/current/mod/core.html#keepalive)
-but with different default parameters than the kernel compiled ones.
+At some point during your Kubernetes journey you will come to the point where you need to adjust some parameters of the underlying node system, either globally or in the context of a specific pod or set of pods. Maybe you are running Redis and need to [increase the amount of allowed maximum connections](https://github.com/redis/redis/blob/unstable/redis.conf#L100) on a socket or you use Apache webserver and want to [enable TCP Keepalive](http://httpd.apache.org/docs/current/mod/core.html#keepalive) but with different default parameters than the kernel compiled ones.
 
-To do so you need to adjust the according sysctl values. By default your
-Kubernetes installation
-[will prevent you from doing so](https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/)
-to ensure a secure and stable workload environment. If you try anyway e.g., by specifying:
+To do so you need to adjust the according sysctl values. By default your Kubernetes installation [will prevent you from doing so](https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/) to ensure a secure and stable workload environment. If you try anyway e.g., by specifying:
 
 ```yaml
 securityContext:
@@ -36,8 +26,7 @@ securityContext:
     value: "10"
 ```
 
-chances are you will see something like this in the event log output for your
-pods:
+chances are you will see something like this in the event log output for your pods:
 
 ```bash
 kubectl describe pod/test
@@ -50,8 +39,7 @@ Events:
   Warning  SysctlForbidden  2s    kubelet            forbidden sysctl: "net.ipv4.tcp_keepalive_time" not whitelisted
 ```
 
-If however you know what you are doing and are aware about the side effects of
-your changes, you can allow non privileged pods to use those sysctls.
+If however you know what you are doing and are aware about the side effects of your changes, you can allow non privileged pods to use those sysctls.
 
 ## Requirements
 
@@ -60,8 +48,7 @@ your changes, you can allow non privileged pods to use those sysctls.
 
 ## Adjusting the kubelet configuration
 
-If you have enabled the dynamic kubelet feature you should find a
-`kubelet-config-1.X` in your kube-system namespace:
+If you have enabled the dynamic kubelet feature you should find a `kubelet-config-1.X` in your kube-system namespace:
 
 ```bash
 kubectl get configmap --namespace kube-system --selector kubermatic-addon=kubelet-configmap
@@ -77,9 +64,7 @@ kubelet-config-1.17   1      1d
 kubelet-config-1.18   1      1d
 ```
 
-In order to allow your pods to set your required sysctl values you first need to
-adjust the configmap corresponding to your current cluster version. You can
-determine it by running e.g.:
+In order to allow your pods to set your required sysctl values you first need to adjust the configmap corresponding to your current cluster version. You can determine it by running e.g.:
 
 ```bash
 kubectl version --short
@@ -88,9 +73,7 @@ Client Version: v1.20.1
 Server Version: v1.18.13
 ```
 
-Edit the configmap resource and add something like this (e.g., if you want to
-tweak the tcp keepalive default values for your pods) below the line that
-contains `kubelet: |`:
+Edit the configmap resource and add something like this (e.g., if you want to tweak the tcp keepalive default values for your pods) below the line that contains `kubelet: |`:
 
 ```yaml
 allowedUnsafeSysctls:
@@ -123,9 +106,7 @@ data:
     ...
 ```
 
-After you have applied the new configmap (or saved it if you used
-`kubectl edit`) you can now verify that the kubelet has in fact
-loaded the new configuration by running the following two commands:
+After you have applied the new configmap (or saved it if you used `kubectl edit`) you can now verify that the kubelet has in fact loaded the new configuration by running the following two commands:
 
 ```bash
 kubectl proxy --port=8001 &
@@ -133,13 +114,9 @@ NODE_NAME="$(kubectl get nodes --output jsonpath='{ .items[0].metadata.name }')"
 curl --silent --show-error --location "http://localhost:8001/api/v1/nodes/${NODE_NAME}/proxy/configz"
 ```
 
-You should see a blob of JSON that contains your new options e.g.,
-`"allowedUnsafeSysctls":["net.ipv4.tcp_keepalive_time","net.ipv4.tcp_keepalive_intvl","net.ipv4.tcp_keepalive_probes"]`
-If you want to know how this works, have a
-[look at the official kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/#generate-the-configuration-file)
+You should see a blob of JSON that contains your new options e.g., `"allowedUnsafeSysctls":["net.ipv4.tcp_keepalive_time","net.ipv4.tcp_keepalive_intvl","net.ipv4.tcp_keepalive_probes"]`.  If you want to know how this works, have a [look at the official kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/#generate-the-configuration-file)
 
-Now you are able to create pods that use those sysctls inside their
-securityContext options e.g.:
+Now you are able to create pods that use those sysctls inside their securityContext options e.g.:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
The current layout makes the text look ragged. This is due to the newlines I added to adhere to a 80 character line length limit. 

To allow dynamic text wrapping lines need to be one line though. This MR fixes that.